### PR TITLE
Update go-1.8-rpm-fpm image to support running as 'gouser'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ A combination of the `golang:1.7` and `golang:1.8` images. The Go 1.7 directory 
 
 go-1.8-rpm-fpm
 --------------
-Docker image based on `golang:1.8` that also has `rpm` and `fpm` installed. The image is set to run as the user "gouser" rather than root.
+Docker image based on `golang:1.8` that also has `rpm` and `fpm` installed. The user creates a user called `gouser`. By default, this user is not used (the container is still run as `root` by default). However, the image contains a script called `/run-as-gouser.sh` that can be used to run the provided commands as `gouser`. The `USER_ID` environment variable can be used to set the UID of `gouser`.

--- a/go-1.8-rpm-fpm/Dockerfile
+++ b/go-1.8-rpm-fpm/Dockerfile
@@ -6,8 +6,9 @@ RUN apt-get -y install ruby-dev
 RUN apt-get -y install rubygems
 RUN gem install fpm
 
-RUN adduser gouser
+ENV USER_ID 1000
+RUN adduser gouser --uid $USER_ID
 RUN chown -R gouser /go
 
-WORKDIR /go
-USER gouser
+COPY ./run-as-gouser.sh /
+RUN chmod +x /run-as-gouser.sh

--- a/go-1.8-rpm-fpm/run-as-gouser.sh
+++ b/go-1.8-rpm-fpm/run-as-gouser.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+# set the UID of gouser to be the value of $USER_ID
+if [ "$(id -u gouser)" -ne "$USER_ID" ]; then
+  usermod -u $USER_ID gouser
+  chown -R gouser /go
+fi
+
+su -c "$@" gouser


### PR DESCRIPTION
Create `gouser` as part of the image and include a script in the
image that allows the UID of the user to be customized.