### PR TITLE
Set JAVA_HOME in go-darwin-linux-no-cgo-java-11

### DIFF
--- a/go-darwin-linux-no-cgo-java-11/Dockerfile_template.txt
+++ b/go-darwin-linux-no-cgo-java-11/Dockerfile_template.txt
@@ -3,4 +3,6 @@ FROM {{Tag "go-darwin-linux-no-cgo" 0 0}}
 RUN mkdir -p /opt/jdk && \
     curl https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz -o /opt/jdk-11.0.1.tgz && \
     tar -xvf /opt/jdk-11.0.1.tgz --strip-components=1 -C /opt/jdk
-ENV PATH="/opt/jdk/bin:${PATH}"
+    
+ENV JAVA_HOME /opt/jdk
+ENV PATH "$PATH:$JAVA_HOME/bin"


### PR DESCRIPTION
```
$ docker run --rm nmiyake/go:go-darwin-linux-1.10.3-docker-17.06.0-ce-java-ruby-netcat-t131 bash -c 'echo $JAVA_HOME' 
/usr/lib/jvm/default-java

$  docker run --rm nmiyake/go:go-darwin-linux-no-cgo-1.11.2-java-11-t140 bash -c 'echo $JAVA_HOME'
<nothing>
```